### PR TITLE
Enable email sharing, file removal, and editable experiment dates

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,6 +16,7 @@ export interface Experiment {
   protocol?: string;
   status?: "planning" | "in_progress" | "completed" | "on_hold";
   visibility?: string;
+  experiment_date?: string;
   created_at: string;
   updated_at?: string;
   tags: any[];

--- a/supabase/experiment_shares.sql
+++ b/supabase/experiment_shares.sql
@@ -121,3 +121,19 @@ for select using (
         where et.tag_id = tags.id and es.user_id = auth.uid()
     )
 );
+
+-- Helper function to lookup a user id by email
+create or replace function get_user_id_by_email(user_email text)
+returns uuid
+language sql
+security definer
+set search_path = auth
+as $$
+  select id from users where email = user_email;
+$$;
+
+grant execute on function get_user_id_by_email to authenticated;
+
+-- Allow experiments to store a custom experiment date
+alter table experiments
+  add column if not exists experiment_date date default now();


### PR DESCRIPTION
## Summary
- allow sharing experiments by recipient email via new RPC lookup
- add ability to delete uploaded protocol and data files
- let users set and update a custom experiment date

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a165da3528832493069a7875694e69