### PR TITLE
feat: display experiments shared by others

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -321,7 +321,7 @@ export default function ResearchPlatform() {
         }
       }
 
-      // Upload protocol files
+      const protocolEntries: any[] = []
       for (const file of newExperiment.protocolFiles) {
         const uploadResult = await uploadFileToStorage(
           file,
@@ -339,10 +339,19 @@ export default function ResearchPlatform() {
               mime_type: file.type,
             },
           ])
+          protocolEntries.push({
+            experiment_id: experimentData.id,
+            name: file.name,
+            file_path: uploadResult.fileName,
+            file_size: file.size,
+            filename: file.name,
+            mime_type: file.type,
+            file_url: uploadResult.publicUrl,
+          })
         }
       }
 
-      // Upload data files
+      const fileEntries: any[] = []
       for (const file of newExperiment.dataFiles) {
         const uploadResult = await uploadFileToStorage(file, experimentData.id, "data")
         if (uploadResult) {
@@ -357,8 +366,30 @@ export default function ResearchPlatform() {
               mime_type: file.type,
             },
           ])
+          fileEntries.push({
+            experiment_id: experimentData.id,
+            name: file.name,
+            file_path: uploadResult.fileName,
+            file_type: "data",
+            file_size: file.size,
+            filename: file.name,
+            mime_type: file.type,
+            file_url: uploadResult.publicUrl,
+          })
         }
       }
+
+      setExperiments((prev) => [
+        {
+          ...experimentData,
+          tags: tags.filter((t) => newExperiment.tag_ids.includes(t.id)),
+          protocols: protocolEntries,
+          files: fileEntries,
+          results: [],
+          shared: false,
+        },
+        ...prev,
+      ])
 
       setNewExperiment({
         title: "",
@@ -372,7 +403,6 @@ export default function ResearchPlatform() {
         dataFiles: [],
       })
       setIsAddExperimentOpen(false)
-      fetchExperiments()
     } catch (err) {
       console.error("Add experiment error:", err)
       alert("An unexpected error occurred. Please try again.")

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -158,8 +158,17 @@ export default function ResearchPlatform() {
         return
       }
 
-      const sharedExperiments = (sharedData || []).map((item: any) => item.experiment)
-      const allExperiments = [...(experimentsData || []), ...sharedExperiments]
+      const ownedExperiments = (experimentsData || []).map((exp: any) => ({
+        ...exp,
+        shared: false,
+      }))
+
+      const sharedExperiments = (sharedData || []).map((item: any) => ({
+        ...item.experiment,
+        shared: true,
+      }))
+
+      const allExperiments = [...ownedExperiments, ...sharedExperiments]
 
       // Fetch related data for each experiment
       const experimentsWithRelations = await Promise.all(
@@ -1099,7 +1108,12 @@ export default function ResearchPlatform() {
                     <CardHeader>
                       <div className="flex items-start justify-between">
                         <div className="space-y-1 flex-1">
-                          <CardTitle className="text-xl">{experiment.title}</CardTitle>
+                          <CardTitle className="text-xl flex items-center gap-2">
+                            {experiment.title}
+                            {experiment.shared && (
+                              <Badge variant="secondary">Shared</Badge>
+                            )}
+                          </CardTitle>
                           <div className="flex items-center gap-2 text-sm text-gray-600">
                             {experiment.researcher_name && (
                               <>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -163,16 +163,20 @@ export default function ResearchPlatform() {
         shared: false,
       }))
 
-      const sharedExperiments = (sharedData || []).map((item: any) => ({
-        ...item.experiment,
-        shared: true,
-      }))
+      const sharedExperiments = (sharedData || [])
+        .filter((item: any) => item.experiment)
+        .map((item: any) => ({
+          ...item.experiment,
+          shared: true,
+        }))
 
-      const allExperiments = [...ownedExperiments, ...sharedExperiments]
+      const validExperiments = [...ownedExperiments, ...sharedExperiments].filter(
+        (exp) => exp && exp.id,
+      )
 
       // Fetch related data for each experiment
       const experimentsWithRelations = await Promise.all(
-        allExperiments.map(async (exp) => {
+        validExperiments.map(async (exp) => {
           // Fetch tags for this experiment
           const { data: tagData } = await supabase
             .from("experiment_tags")
@@ -678,7 +682,7 @@ export default function ResearchPlatform() {
 
   const filteredExperiments = experiments.filter((exp) => {
     const matchesSearch =
-      exp.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (exp.title && exp.title.toLowerCase().includes(searchTerm.toLowerCase())) ||
       (exp.description && exp.description.toLowerCase().includes(searchTerm.toLowerCase())) ||
       (exp.researcher_name && exp.researcher_name.toLowerCase().includes(searchTerm.toLowerCase()))
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,4 +23,8 @@ export interface Experiment {
   protocols: any[];
   files: any[];
   results: any[];
+  /**
+   * Indicates if the experiment is shared with the current user rather than owned
+   */
+  shared?: boolean;
 }


### PR DESCRIPTION
## Summary
- fetch experiments shared with current user and mark them as shared
- show badge on experiments shared by others

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a211e15cd48324bd3a48e818330e04