### PR TITLE
Display experiments shared by other users

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -202,6 +202,7 @@ export default function ResearchPlatform() {
 
           return {
             ...exp,
+            shared: exp.user_id !== user.id,
             tags: tagData?.map((item: any) => item.tags).filter(Boolean) || [],
             protocols: mapWithUrl(protocolData),
             files: mapWithUrl(fileData),
@@ -1117,6 +1118,11 @@ export default function ResearchPlatform() {
                           <Badge className={getStatusColor(experiment.status || "planning")}>
                             {(experiment.status || "planning").replace("_", " ")}
                           </Badge>
+                          {experiment.shared && (
+                            <Badge className="bg-purple-100 text-purple-800">
+                              Shared
+                            </Badge>
+                          )}
                           {experiment.user_id === user?.id && (
                             <DropdownMenu>
                               <DropdownMenuTrigger asChild>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,4 +23,5 @@ export interface Experiment {
   protocols: any[];
   files: any[];
   results: any[];
+  shared?: boolean;
 }


### PR DESCRIPTION
## Summary
- mark experiments as shared if they belong to another user
- show a "Shared" badge on experiments not owned by the current user
- extend Experiment type with optional `shared` flag

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a211e15cd48324bd3a48e818330e04