### PR TITLE
Prevent duplicate experiment shares

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -135,44 +135,46 @@ export default function ResearchPlatform() {
     try {
       setLoading(true)
 
-      // Fetch experiments owned by the current user
-      const { data: experimentsData, error: experimentsError } = await supabase
+      // Fetch IDs of experiments shared with the current user
+      const { data: shareRows, error: shareError } = await supabase
+        .from("experiment_shares")
+        .select("experiment_id")
+        .eq("user_id", user.id)
+
+      if (shareError) {
+        console.error("Error fetching shared experiments:", shareError)
+        return
+      }
+
+      const sharedIds = shareRows?.map((row: any) => row.experiment_id) || []
+
+      // Fetch experiments owned by the user or shared with them
+      let query = supabase
         .from("experiments")
         .select("*")
-        .eq("user_id", user.id)
         .order("created_at", { ascending: false })
+
+      if (sharedIds.length > 0) {
+        query = query.or(
+          `user_id.eq.${user.id},id.in.(${sharedIds.join(",")})`,
+        )
+      } else {
+        query = query.eq("user_id", user.id)
+      }
+
+      const { data: experimentsData, error: experimentsError } = await query
 
       if (experimentsError) {
         console.error("Error fetching experiments:", experimentsError)
         return
       }
 
-      // Fetch experiments shared with the current user
-      const { data: sharedData, error: sharedError } = await supabase
-        .from("experiment_shares")
-        .select("experiment:experiments(*)")
-        .eq("user_id", user.id)
-
-      if (sharedError) {
-        console.error("Error fetching shared experiments:", sharedError)
-        return
-      }
-
-      const ownedExperiments = (experimentsData || []).map((exp: any) => ({
-        ...exp,
-        shared: false,
-      }))
-
-      const sharedExperiments = (sharedData || [])
-        .filter((item: any) => item.experiment)
-        .map((item: any) => ({
-          ...item.experiment,
-          shared: true,
+      const validExperiments = (experimentsData || [])
+        .filter((exp: any) => exp && exp.id)
+        .map((exp: any) => ({
+          ...exp,
+          shared: exp.user_id !== user.id,
         }))
-
-      const validExperiments = [...ownedExperiments, ...sharedExperiments].filter(
-        (exp) => exp && exp.id,
-      )
 
       // Fetch related data for each experiment
       const experimentsWithRelations = await Promise.all(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -523,6 +523,24 @@ export default function ResearchPlatform() {
         return
       }
 
+      const { data: existingShare, error: existingError } = await supabase
+        .from("experiment_shares")
+        .select("id")
+        .eq("experiment_id", shareExperiment.id)
+        .eq("user_id", userId)
+        .maybeSingle()
+
+      if (existingError) {
+        console.error("Error checking existing share:", existingError)
+        alert("Failed to share experiment. Please try again.")
+        return
+      }
+
+      if (existingShare) {
+        alert("Experiment already shared with this user.")
+        return
+      }
+
       const { error } = await supabase.from("experiment_shares").insert({
         experiment_id: shareExperiment.id,
         user_id: userId,

--- a/supabase/experiment_shares.sql
+++ b/supabase/experiment_shares.sql
@@ -3,7 +3,8 @@ create table if not exists experiment_shares (
     id uuid primary key default gen_random_uuid(),
     experiment_id uuid not null references experiments(id) on delete cascade,
     user_id uuid not null references auth.users(id) on delete cascade,
-    created_at timestamptz default now()
+    created_at timestamptz default now(),
+    unique (experiment_id, user_id)
 );
 
 -- Enable row level security


### PR DESCRIPTION
## Summary
- ensure experiment shares are unique per experiment and user
- avoid inserting duplicate shares by checking existing entries

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npx supabase db reset` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e20d80dc832480800ba348501e05