### PR TITLE
feat: allow viewing shared experiments

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,6 +53,7 @@ export default function ResearchPlatform() {
   const [searchTerm, setSearchTerm] = useState("")
   const [statusFilter, setStatusFilter] = useState<string>("all")
   const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [experimentView, setExperimentView] = useState<"owned" | "shared">("owned")
   const [isAddExperimentOpen, setIsAddExperimentOpen] = useState(false)
   const [editingExperiment, setEditingExperiment] = useState<Experiment | null>(null)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
@@ -135,24 +136,41 @@ export default function ResearchPlatform() {
     try {
       setLoading(true)
 
-      const { data: experimentsData, error: experimentsError } = await supabase
+      const { data: ownedData, error: ownedError } = await supabase
         .from("experiments")
         .select("*")
         .order("created_at", { ascending: false })
 
-      if (experimentsError) {
-        console.error("Error fetching experiments:", experimentsError)
+      if (ownedError) {
+        console.error("Error fetching experiments:", ownedError)
         return
       }
 
-      const validExperiments = (experimentsData || []).map((exp: any) => ({
+      const ownedExperiments = (ownedData || []).map((exp: any) => ({
         ...exp,
-        shared: exp.user_id !== user.id,
+        shared: false,
       }))
+
+      const { data: sharedData, error: sharedError } = await supabase
+        .from("shared_experiments_view")
+        .select("*")
+        .order("created_at", { ascending: false })
+
+      if (sharedError) {
+        console.error("Error fetching shared experiments:", sharedError)
+        return
+      }
+
+      const sharedExperiments = (sharedData || []).map((exp: any) => ({
+        ...exp,
+        shared: true,
+      }))
+
+      const allExperiments = [...ownedExperiments, ...sharedExperiments]
 
       // Fetch related data for each experiment
       const experimentsWithRelations = await Promise.all(
-        validExperiments.map(async (exp) => {
+        allExperiments.map(async (exp) => {
           // Fetch tags for this experiment
           const { data: tagData } = await supabase
             .from("experiment_tags")
@@ -667,7 +685,9 @@ export default function ResearchPlatform() {
     const matchesTags =
       selectedTags.length === 0 || selectedTags.some((tagId) => exp.tags.some((tag) => tag.id === tagId))
 
-    return matchesSearch && matchesStatus && matchesTags
+    const matchesView = experimentView === "shared" ? exp.shared : !exp.shared
+
+    return matchesSearch && matchesStatus && matchesTags && matchesView
   })
 
   const getStatusColor = (status: string) => {
@@ -1099,6 +1119,18 @@ export default function ResearchPlatform() {
             </Dialog>
 
             {/* Experiments List */}
+            <Tabs
+              value={experimentView}
+              onValueChange={(v) => setExperimentView(v as "owned" | "shared")}
+              className="space-y-4"
+            >
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="owned">My Experiments</TabsTrigger>
+                <TabsTrigger value="shared">Shared with Me</TabsTrigger>
+              </TabsList>
+              <TabsContent value="owned" />
+              <TabsContent value="shared" />
+            </Tabs>
             <div className="space-y-4">
               {loading ? (
                 <Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -135,11 +135,9 @@ export default function ResearchPlatform() {
     try {
       setLoading(true)
 
-      // Fetch experiments owned by the current user
       const { data: experimentsData, error: experimentsError } = await supabase
         .from("experiments")
         .select("*")
-        .eq("user_id", user.id)
         .order("created_at", { ascending: false })
 
       if (experimentsError) {
@@ -147,32 +145,10 @@ export default function ResearchPlatform() {
         return
       }
 
-      // Fetch experiments shared with the current user
-      const { data: sharedData, error: sharedError } = await supabase
-        .from("experiment_shares")
-        .select("experiment:experiments(*)")
-        .eq("user_id", user.id)
-
-      if (sharedError) {
-        console.error("Error fetching shared experiments:", sharedError)
-        return
-      }
-
-      const ownedExperiments = (experimentsData || []).map((exp: any) => ({
+      const validExperiments = (experimentsData || []).map((exp: any) => ({
         ...exp,
-        shared: false,
+        shared: exp.user_id !== user.id,
       }))
-
-      const sharedExperiments = (sharedData || [])
-        .filter((item: any) => item.experiment)
-        .map((item: any) => ({
-          ...item.experiment,
-          shared: true,
-        }))
-
-      const validExperiments = [...ownedExperiments, ...sharedExperiments].filter(
-        (exp) => exp && exp.id,
-      )
 
       // Fetch related data for each experiment
       const experimentsWithRelations = await Promise.all(

--- a/database-schema
+++ b/database-schema
@@ -844,11 +844,11 @@
           "permissive": "PERMISSIVE"
         },
         {
-          "name": "Users can view own or shared experiments",
+          "name": "Enable read for own experiments",
           "roles": [
             "public"
           ],
-          "using": "user_can_access_experiment(id)",
+          "using": "(auth.uid() = user_id)",
           "command": "SELECT",
           "permissive": "PERMISSIVE"
         },
@@ -2229,15 +2229,6 @@
           ],
           "using": "(auth.uid() = user_id)",
           "command": "ALL",
-          "permissive": "PERMISSIVE"
-        },
-        {
-          "name": "View shared tags",
-          "roles": [
-            "public"
-          ],
-          "using": "(auth.uid() = user_id) OR EXISTS ( SELECT 1 FROM experiment_tags et WHERE (et.tag_id = tags.id) AND user_can_access_experiment(et.experiment_id))",
-          "command": "SELECT",
           "permissive": "PERMISSIVE"
         }
       ],

--- a/database-schema
+++ b/database-schema
@@ -844,11 +844,11 @@
           "permissive": "PERMISSIVE"
         },
         {
-          "name": "Enable read for own experiments",
+          "name": "Users can view own or shared experiments",
           "roles": [
             "public"
           ],
-          "using": "(auth.uid() = user_id)",
+          "using": "user_can_access_experiment(id)",
           "command": "SELECT",
           "permissive": "PERMISSIVE"
         },
@@ -2229,6 +2229,15 @@
           ],
           "using": "(auth.uid() = user_id)",
           "command": "ALL",
+          "permissive": "PERMISSIVE"
+        },
+        {
+          "name": "View shared tags",
+          "roles": [
+            "public"
+          ],
+          "using": "(auth.uid() = user_id) OR EXISTS ( SELECT 1 FROM experiment_tags et WHERE (et.tag_id = tags.id) AND user_can_access_experiment(et.experiment_id))",
+          "command": "SELECT",
           "permissive": "PERMISSIVE"
         }
       ],

--- a/supabase/experiment_shares.sql
+++ b/supabase/experiment_shares.sql
@@ -78,36 +78,31 @@ with check (auth.uid() = user_id);
 drop policy if exists "View own or shared experiments" on experiments;
 create policy "View own or shared experiments" on experiments
 for select using (
-    auth.uid() = user_id
-    or auth.uid() in (select user_id from experiment_shares where experiment_id = id)
+    user_can_access_experiment(id)
 );
 
 drop policy if exists "View shared protocols" on protocols;
 create policy "View shared protocols" on protocols
 for select using (
-    auth.uid() = (select user_id from experiments where id = experiment_id)
-    or auth.uid() in (select user_id from experiment_shares where experiment_id = protocols.experiment_id)
+    user_can_access_experiment(experiment_id)
 );
 
 drop policy if exists "View shared files" on files;
 create policy "View shared files" on files
 for select using (
-    auth.uid() = (select user_id from experiments where id = experiment_id)
-    or auth.uid() in (select user_id from experiment_shares where experiment_id = files.experiment_id)
+    user_can_access_experiment(experiment_id)
 );
 
 drop policy if exists "View shared results" on results;
 create policy "View shared results" on results
 for select using (
-    auth.uid() = (select user_id from experiments where id = experiment_id)
-    or auth.uid() in (select user_id from experiment_shares where experiment_id = results.experiment_id)
+    user_can_access_experiment(experiment_id)
 );
 
 drop policy if exists "View shared experiment tags" on experiment_tags;
 create policy "View shared experiment tags" on experiment_tags
 for select using (
-    auth.uid() = (select user_id from experiments where id = experiment_id)
-    or auth.uid() in (select user_id from experiment_shares where experiment_id = experiment_tags.experiment_id)
+    user_can_access_experiment(experiment_id)
 );
 
 drop policy if exists "View shared tags" on tags;
@@ -116,9 +111,9 @@ for select using (
     auth.uid() = user_id
     or exists (
         select 1
-        from experiment_shares es
-        join experiment_tags et on es.experiment_id = et.experiment_id
-        where et.tag_id = tags.id and es.user_id = auth.uid()
+        from experiment_tags et
+        where et.tag_id = tags.id
+          and user_can_access_experiment(et.experiment_id)
     )
 );
 


### PR DESCRIPTION
## Summary
- allow selecting experiments shared with the user via new RLS policy
- expose tags on shared experiments
- switch supabase policies to use `user_can_access_experiment`

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a482d1f88c8324812b9c5576883765